### PR TITLE
Feat/footer header 마크업과 스타일링

### DIFF
--- a/React/src/components/Footer.tsx
+++ b/React/src/components/Footer.tsx
@@ -1,4 +1,0 @@
-function Footer() {
-  return <p>여기는 푸터입니다.</p>;
-}
-export default Footer;

--- a/React/src/components/Footer/Footer.tsx
+++ b/React/src/components/Footer/Footer.tsx
@@ -1,0 +1,17 @@
+import iconHome from '../../assets/icon/icon-home.svg'; // 경로 수정
+import iconMessageCircle from '../../assets/icon/icon-message-circle.svg';
+import iconEdit from '../../assets/icon/icon-edit.svg';
+import iconUser from '../../assets/icon/icon-user.svg';
+import NavButton from './component/NavButton';
+
+function Footer() {
+  return (
+    <nav className="fixed bottom-0 flex justify-center gap-[14px] w-full h-[60px] border-t border-t-[#DBDBDB]">
+      <NavButton imgSrc={iconHome} name="홈" />
+      <NavButton imgSrc={iconMessageCircle} name="채팅" />
+      <NavButton imgSrc={iconEdit} name="게시물 작성" />
+      <NavButton imgSrc={iconUser} name="프로필" />
+    </nav>
+  );
+}
+export default Footer;

--- a/React/src/components/Footer/component/NavButton.tsx
+++ b/React/src/components/Footer/component/NavButton.tsx
@@ -1,0 +1,15 @@
+type NavButtonProps = {
+  imgSrc: string;
+  name: string;
+};
+
+function NavButton({ imgSrc, name }: NavButtonProps) {
+  return (
+    <button className="w-[84px] h-[60px] flex flex-col items-center gap-1">
+      <img src={imgSrc} alt={name} className="w-6 h-6 mt-3" />
+      <span className="text-[10px] text-[#767676]">{name}</span>
+    </button>
+  );
+}
+
+export default NavButton;

--- a/React/src/components/Header.tsx
+++ b/React/src/components/Header.tsx
@@ -1,4 +1,15 @@
+import iconSearch from '../assets/icon/icon-search.png';
+
 function Header() {
-  return <h1>여기는 헤더입니다.</h1>;
+  return (
+    <nav className="flex justify-center w-full h-[48px] border-b border-b-[#DBDBDB] px-[16px] py-[12px]">
+      <div className="flex justify-between items-center w-full max-w-[384px]">
+        <h1 className="text-lg">감귤마켓 피드</h1>
+        <button>
+          <img src={iconSearch} alt="검색" />
+        </button>
+      </div>
+    </nav>
+  );
 }
 export default Header;


### PR DESCRIPTION
## 제목

Footer Header 마크업과 스타일링

## 변경사항 요약

- 주요 변경점
Header에 기본 디자인 적용

Footer에 기본 디자인 적용
 - 푸터 버튼 컴포넌트화
 - 


## 스크린샷

<img width="454" height="924" alt="스크린샷 2025-09-04 12 10 02" src="https://github.com/user-attachments/assets/b2700e75-f22c-4a3f-b26f-30242611c779" />

## 리뷰어

@MeinSchatzMeinSatz  @gyeone 
