### PR TITLE
feat/ homepage 스타일링 작성, footer 겹침 문제 수정

### DIFF
--- a/React/src/components/Footer/Footer.tsx
+++ b/React/src/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ import NavButton from './component/NavButton';
 
 function Footer() {
   return (
-    <nav className="fixed bottom-0 flex justify-center gap-[14px] w-full h-[60px] border-t border-t-[#DBDBDB]">
+    <nav className="fixed bottom-0 flex justify-center gap-[14px] w-full h-[60px] border-t border-t-[#DBDBDB] bg-white">
       <NavButton imgSrc={iconHome} name="홈" />
       <NavButton imgSrc={iconMessageCircle} name="채팅" />
       <NavButton imgSrc={iconEdit} name="게시물 작성" />

--- a/React/src/pages/home/HomePage.tsx
+++ b/React/src/pages/home/HomePage.tsx
@@ -1,9 +1,19 @@
+import Symbol from '../../assets/symbol-logo-gray.png';
+import Header from '../../components/Header';
+import Footer from '../../components/Footer/Footer';
+
 function HomePage() {
   return (
     <div>
-      <img src="" alt="" />
-      <p>유저를 검색해 팔로우 해보세요!</p>
-      <button type="button">검색하기</button>
+      <Header />
+      <div className="mt-[220px] flex flex-col items-center gap-[20px]">
+        <img src={Symbol} alt="로고" />
+        <p className="text-[#767676]">유저를 검색해 팔로우 해보세요!</p>
+        <button type="button" className="w-[120px] h-[44px] bg-[#f26e22] text-sm text-white rounded-full">
+          검색하기
+        </button>
+      </div>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## 제목

homepage 스타일링 작성, footer 겹침 문제 수정

## 변경사항 요약

홈페이지에 CSS 작성
푸터의 위치가 바텀 fixed라서 컨텐츠와 겹치는 문제를 해결하기 위해 푸터에 배경 삽입.

## 스크린샷
<img width="436" height="921" alt="스크린샷 2025-09-04 14 17 43" src="https://github.com/user-attachments/assets/b55182c2-e387-42d8-9f72-fdb70af25a2a" />


## 리뷰어

@MeinSchatzMeinSatz  @gyeone 