### PR TITLE
feat/chatList와 chatRoom페이지의 마크업과 테일윈드 css 적용, textInput 수정

### DIFF
--- a/React/src/components/TextInput.tsx
+++ b/React/src/components/TextInput.tsx
@@ -48,7 +48,7 @@ function TextInput({
         value={inputValue ?? ''}
         onChange={(e) => onChange?.(inputType === 'number' ? Number(e.target.value) : e.target.value)}
         placeholder={placeholderText}
-        className="border-[#DBDBDB] border-b-[1px] focus:outline-none  focus:border-[#F26E22] text-[#000000] text-[14px]"
+        className="border-[#DBDBDB] border-b-[1px] focus:outline-none  focus:border-[#F26E22] text-[14px] placeholder-[#DBDBDB]"
       />
 
       {showErrorMessage && errorMessage && <span className="text-[12px] text-[#EB5757] mt-[6px]">{errorMessage}</span>}

--- a/React/src/components/TextInput.tsx
+++ b/React/src/components/TextInput.tsx
@@ -1,48 +1,57 @@
 // TextInput 사용 또는 기능 구현 시 참고 사항
-// - 필수 props: id, content
-// - 선택적 props: type(기본: text), placeholder, ex, isEx(기본: false)
-// - props로 받을 필요 없음(기능 구현 시에만 필요): value, onChange
-// - ex 존재 시 'isEX = true' 무조건 넘겨주기
+// - 필수 props: inputId, labelText
+// - 선택적 props: inputType(기본: text), placeholderText, errorMessage, showErrorMessage(기본: false)
+// - props로 받을 필요 없음(기능 구현 시에만 필요): inputValue, onChange
+// - errorMessage 존재 시 'showErrorMessage = true' 무조건 넘겨주기
 type InputType = 'text' | 'number' | 'password' | 'email' | 'url';
 
 type TextInputProps = {
-  id: string;
-  content: string;
-  type?: InputType;
-  placeholder?: string;
-  ex?: string;
-  value?: string | number;
+  inputId: string;
+  labelText: string;
+  inputType?: InputType;
+  placeholderText?: string;
+  errorMessage?: string;
+  inputValue?: string | number;
   onChange?: (value: string | number) => void;
-  isEx?: boolean;
+  showErrorMessage?: boolean;
 };
 
 /**
  *
- * @param {string} id - input의 id 속성 값
- * @param {string} content - label의 textContent
- * @param {string} type - input의 type 속성 값
- * @param {string} placeholder - input의 placeholder
- * @param {string} ex - input값 예외처리 후 안내 문구
- * @param {string | number} value - input value 속성 값
+ * @param {string} inputId - input의 id 속성 값
+ * @param {string} labelText - label의 textContent
+ * @param {string} inputType - input의 type 속성 값
+ * @param {string} placeholderText - input의 placeholder
+ * @param {string} errorMessage - input값 예외처리 후 안내 문구
+ * @param {string | number} inputValue - input value 속성 값
  * @param {(value: string | number) => void} onChange - 값이 바뀔 때 호출되는 콜백
- * @param {boolean} isEx - 안내 문구(ex)를 보여줄지 여부
+ * @param {boolean} showErrorMessage - 안내 문구(errorMessage)를 보여줄지 여부
  */
-function TextInput({ id, content, type = 'text', placeholder, ex, value, onChange, isEx = false }: TextInputProps) {
+function TextInput({
+  inputId,
+  labelText,
+  inputType = 'text',
+  placeholderText,
+  errorMessage,
+  inputValue,
+  onChange,
+  showErrorMessage = false,
+}: TextInputProps) {
   return (
-    <div className="flex flex-col px-[34px]">
-      <label htmlFor={id} className="text-[12px] text-[#767676] ">
-        {content}
+    <div className="flex flex-col w-[322px]">
+      <label htmlFor={inputId} className="text-[12px] text-[#767676] ">
+        {labelText}
       </label>
       <input
-        id={id}
-        type={type}
-        value={value ?? ''}
-        onChange={(e) => onChange?.(type === 'number' ? Number(e.target.value) : e.target.value)}
-        placeholder={placeholder}
+        id={inputId}
+        type={inputType}
+        value={inputValue ?? ''}
+        onChange={(e) => onChange?.(inputType === 'number' ? Number(e.target.value) : e.target.value)}
+        placeholder={placeholderText}
         className="border-[#DBDBDB] border-b-[1px] focus:outline-none  focus:border-[#F26E22] text-[#000000] text-[14px]"
       />
 
-      {isEx && ex && <span className="text-[12px] text-[#EB5757] mt-[6px]">{ex}</span>}
+      {showErrorMessage && errorMessage && <span className="text-[12px] text-[#EB5757] mt-[6px]">{errorMessage}</span>}
     </div>
   );
 }

--- a/React/src/pages/chat/ChatList.tsx
+++ b/React/src/pages/chat/ChatList.tsx
@@ -1,0 +1,54 @@
+import Footer from '../../components/Footer/Footer';
+import Header from '../../components/Header';
+import profileImg from '../../assets/basic-profile-img.png';
+
+function ChatList() {
+  return (
+    <>
+      <Header />
+      <ul className="flex flex-col gap-5 pt-6 px-[16px]">
+        <li className="flex gap-3 items-end w-full justify-between">
+          <div className="relative">
+            <span className="w-3 h-3 bg-[#F26E22] rounded-full absolute top-0"></span>
+            <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
+          </div>
+
+          <div className="flex flex-col gap-1 flex-1 ">
+            <h2 className="text-sm">애월읍 위니브 감귤농장</h2>
+            <p className="text-[12px] text-[#767676] mb-[3px]">이번에 정정 언제하맨마씸?</p>
+          </div>
+          <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
+        </li>
+
+        <li className="flex gap-3 items-end w-full justify-between">
+          <div className="relative">
+            <span className="w-3 h-3 bg-[#F26E22] rounded-full absolute top-0"></span>
+            <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
+          </div>
+
+          <div className="flex flex-col gap-1 flex-1 min-w-0">
+            <h2 className="text-sm">제주감귤마을</h2>
+            <p className="text-[12px] text-[#767676] mb-[3px] truncate">
+              깊은 어둠의 존재감, 롤스로이스 뉴 블랙 배지...
+            </p>
+          </div>
+          <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
+        </li>
+
+        <li className="flex gap-3 items-end w-full justify-between">
+          <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
+          <div className="flex flex-col gap-1 flex-1 min-w-0">
+            <h2 className="text-sm">누구네 농장 친환경 한라봉</h2>
+            <p className="text-[12px] text-[#767676] mb-[3px] truncate">
+              내 차는 내가 평가한다. 오픈 이벤트에 참여 하...
+            </p>
+          </div>
+          <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
+        </li>
+      </ul>
+      <Footer />
+    </>
+  );
+}
+
+export default ChatList;

--- a/React/src/pages/chat/ChatRoom.tsx
+++ b/React/src/pages/chat/ChatRoom.tsx
@@ -1,0 +1,71 @@
+import { ChangeEvent, useState } from 'react';
+import Header from '../../components/Header';
+import uploadFileImg from '../../assets/upload-file.png';
+import profileImg from '../../assets/basic-profile-img.png';
+import dogImg from '../../assets/chat-exapmle.png';
+
+function ChatRoom() {
+  // 메세지 입력값 관리
+  const [message, setMessage] = useState('');
+  // 파일 선택 여부 관리
+  const [fileSelected, setFileSelected] = useState(false);
+
+  function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    setFileSelected(!!e.target.files?.length);
+  }
+
+  return (
+    <div className="h-screen">
+      <Header />
+      <section className=" flex flex-col gap-[9px] px-4 pb-[81px] h-[calc(100%-48px)] justify-end bg-[#f2f2f2] overflow-y-auto">
+        <div className="flex justify-start gap-3">
+          <img className="w-[42px] h-[42px] rounded-full" src={profileImg} alt="채팅 상대방 프로필" />
+          <div className="flex items-end gap-[6px]">
+            <p className="text-[14px] p-3 bg-white border rounded-b-[10px] rounded-tr-[10px] border-[#C4C4C4]">
+              옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다. 이상의 청춘의 뼈 따뜻한 그들의 그와
+              약동하다. 대고, 못할 넣는 풍부하게 뛰노는 인생의 힘있다.
+            </p>
+            <time className="text-[10px] text-[#767676] ">12:39</time>
+          </div>
+        </div>
+        <div className="flex justify-start gap-3">
+          <img className="w-[42px] h-[42px] rounded-full" src={profileImg} alt="채팅 상대방 프로필" />
+          <div className="flex items-end gap-[6px]">
+            <p className="text-[14px] p-3 bg-white border rounded-b-[10px] rounded-tr-[10px] border-[#C4C4C4]">
+              안녕하세요. 감귤 사고싶어요요요요요
+            </p>
+            <time className="text-[10px] text-[#767676] ">12:41</time>
+          </div>
+        </div>
+        <div className="flex justify-end items-end gap-[6px] mt-[1px]">
+          <time className="text-[10px] text-[#767676] ">12:50</time>
+          <p className="text-[14px] text-white p-3 bg-[#F26E22] rounded-b-[10px] rounded-tl-[10px]">네 말씀하세요.</p>
+        </div>
+        <div className="flex justify-end items-end gap-[6px] mt-[1px]">
+          <time className="text-[10px] text-[#767676] ">12:51</time>
+          <img className="w-60 h-60 rounded-[10px]" src={dogImg} alt="웃고있는 강아지" />
+        </div>
+      </section>
+      <form className="fixed bottom-0 flex items-center justify-center w-full h-[60px] border-t border-t-[#DBDBDB] bg-white">
+        <label className="w-9 h-9 cursor-pointer" htmlFor="imgSelectBtn">
+          <img src={uploadFileImg} alt="채팅에 보낼 이미지 파일 선택" />
+          <input id="imgSelectBtn" type="file" className="hidden" onChange={handleFileChange} />
+        </label>
+        <input
+          className="w-[278px] ml-[18px] text-[14px] placeholder-[#C4C4C4]"
+          type="text"
+          placeholder="메세지 입력하기..."
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <button
+          className={`text-[14px] ${message || fileSelected ? 'text-[#F26E22]' : 'text-[#C4C4C4]'}`}
+          type="button"
+        >
+          전송
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default ChatRoom;

--- a/React/src/pages/profileModification/ProfileModification.tsx
+++ b/React/src/pages/profileModification/ProfileModification.tsx
@@ -14,9 +14,13 @@ function ProfileModification() {
         </button>
       </div>
       <form>
-        <TextInput id="userName" content="사용자 이름" placeholder="2~10자 이내여야 합니다." />
-        <TextInput id="accountId" content="계정 ID" placeholder="영문, 숫자, 특수문자(.),(_)만 사용 가능합니다." />
-        <TextInput id="userName" content="소개" placeholder="자신과 판매할 상품에 대해 소개해 주세요!" />
+        <TextInput inputId="userName" labelText="사용자 이름" placeholderText="2~10자 이내여야 합니다." />
+        <TextInput
+          inputId="accountId"
+          labelText="계정 ID"
+          placeholderText="영문, 숫자, 특수문자(.),(_)만 사용 가능합니다."
+        />
+        <TextInput inputId="userName" labelText="소개" placeholderText="자신과 판매할 상품에 대해 소개해 주세요!" />
       </form>
     </>
   );


### PR DESCRIPTION
## 제목

- feat/chatList와 chatRoom페이지의 마크업과 테일윈드 css 적용, textInput 수정

## 변경사항 요약
- chatList 페이지:  마크업과 테일윈드 css 적용
-  chatRoom 페이지: 마크업과 테일윈드 css 적용
-  textInput 컴포넌트: type이름 직관적으로 변경, placeholder 색상 설정

## 스크린샷

<img width="383" height="777" alt="image" src="https://github.com/user-attachments/assets/02c336d0-7b4d-4899-8bf5-07029505921c" />     
<img width="386" height="831" alt="image" src="https://github.com/user-attachments/assets/ed9b211b-3cca-47cc-9181-bb8b9151c6e6" />

## 리뷰어

- @MeinSchatzMeinSatz @MinKyeongHyeon 
