### PR TITLE
refactor/Linkto태그를 li 태그내부로 이동

### DIFF
--- a/React/src/pages/chat/ChatList.tsx
+++ b/React/src/pages/chat/ChatList.tsx
@@ -8,27 +8,25 @@ function ChatList() {
     <>
       <Header />
       <ul className="flex flex-col gap-5 pt-6 px-[16px]">
-        <Link to="/chat-room">
-          <li className="flex gap-3 items-end w-full justify-between">
+        <li className="flex gap-3 items-end w-full justify-between">
+          <Link to="/chat-room">
             <div className="relative">
               <span className="w-3 h-3 bg-[#F26E22] rounded-full absolute top-0"></span>
               <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
             </div>
-
             <div className="flex flex-col gap-1 flex-1 ">
               <h2 className="text-sm font-medium">애월읍 위니브 감귤농장</h2>
               <p className="text-[12px] text-[#767676] mb-[3px]">이번에 정정 언제하맨마씸?</p>
             </div>
             <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
-          </li>
-        </Link>
-        <Link to="/chat-room">
-          <li className="flex gap-3 items-end w-full justify-between">
+          </Link>
+        </li>
+        <li className="flex gap-3 items-end w-full justify-between">
+          <Link to="/chat-room">
             <div className="relative">
               <span className="w-3 h-3 bg-[#F26E22] rounded-full absolute top-0"></span>
               <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
             </div>
-
             <div className="flex flex-col gap-1 flex-1 min-w-0">
               <h2 className="text-sm font-medium">제주감귤마을</h2>
               <p className="text-[12px] text-[#767676] mb-[3px] truncate">
@@ -36,10 +34,10 @@ function ChatList() {
               </p>
             </div>
             <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
-          </li>
-        </Link>
-        <Link to="/chat-room">
-          <li className="flex gap-3 items-end w-full justify-between">
+          </Link>
+        </li>
+        <li className="flex gap-3 items-end w-full justify-between">
+          <Link to="/chat-room">
             <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
             <div className="flex flex-col gap-1 flex-1 min-w-0">
               <h2 className="text-sm font-medium">누구네 농장 친환경 한라봉</h2>
@@ -48,8 +46,8 @@ function ChatList() {
               </p>
             </div>
             <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
-          </li>
-        </Link>
+          </Link>
+        </li>
       </ul>
       <Footer />
     </>


### PR DESCRIPTION
## 제목

- refactor/Linkto태그를 li 태그내부로 이동

## 변경사항 요약

- chatList페이지의 Linkto태그를 li 태그내부로 이동

## 리뷰어

- @MeinSchatzMeinSatz @MinKyeongHyeon 
