### PR TITLE
Feat/헤더,모달컴포넌트(임시) 기능구현

### DIFF
--- a/React/src/components/Header.tsx
+++ b/React/src/components/Header.tsx
@@ -10,7 +10,7 @@ interface IHeaderProps {
   navStyle: 'top-main' | 'top-search' | 'top-basic' | 'top-chat' | 'top-upload';
   button?: boolean;
   searchValue?: string;
-  searchOnChange?: (e: React.ChangeEvent<HTMLElement>) => void;
+  searchOnChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 /**

--- a/React/src/components/Header.tsx
+++ b/React/src/components/Header.tsx
@@ -1,15 +1,113 @@
+import { Link, useNavigate } from 'react-router-dom';
 import iconSearch from '../assets/icon/icon-search.png';
+import arrowLeft from '../assets/icon/icon-arrow-left.png';
+import more from '../assets/icon/icon-more-vertical.png';
+import Modal from './modal/Modal';
+import Button from './button/Button';
+import { useState } from 'react';
 
-function Header() {
+interface IHeaderProps {
+  navStyle: 'top-main' | 'top-search' | 'top-basic' | 'top-chat' | 'top-upload';
+  button?: boolean;
+}
+
+/**
+ * @param navStyle - 헤더 네비게이션 스타일을 입력하세요. top-main | top-search | top-basic | top-chat | top-upload
+ * @param button - (옵셔널) top-upload 스타일 사용시 '저장'버튼의 disabled를 컨트롤 하는 prop입니다.
+ * @returns
+ * 사용 예시: <Header navStyle="top-upload" button={true} />
+ */
+function Header({ navStyle, button = false }: IHeaderProps) {
+  const [showModal, setShowModal] = useState(false);
+  const navigate = useNavigate();
+
+  const navContent = () => {
+    switch (navStyle) {
+      case 'top-main': {
+        return (
+          <>
+            <h1 className="text-lg">감귤마켓 피드</h1>
+            <Link to="/search-page">
+              <img src={iconSearch} alt="검색" />
+            </Link>
+          </>
+        );
+      }
+      case 'top-search': {
+        return (
+          <>
+            <button onClick={() => navigate(-1)}>
+              <img src={arrowLeft} alt="뒤로가기" />
+            </button>
+            <input
+              type="text"
+              name="search"
+              id="search"
+              placeholder="계정 검색"
+              className="placeholder:text-[#c4c4c4] bg-[#F2F2F2] w-[316px] h-[32px] rounded-[16px] pl-[16px] py-[7px] text-sm"
+            />
+          </>
+        );
+      }
+      case 'top-basic': {
+        return (
+          <>
+            <button onClick={() => navigate(-1)}>
+              <img src={arrowLeft} alt="뒤로가기" />
+            </button>
+            <button type="button" onClick={() => setShowModal(true)}>
+              <img src={more} alt="더보기" />
+            </button>
+          </>
+        );
+      }
+      case 'top-chat': {
+        // 채팅 기능은 추후 구현 예정이라 하드코딩 돼있습니다.
+        return (
+          <>
+            <div className="flex gap-[10px]">
+              <button onClick={() => navigate(-1)}>
+                <img src={arrowLeft} alt="뒤로가기" />
+              </button>
+              <p className="text-sm">애월읍 위니브 감귤농장</p>
+            </div>
+            <button type="button" onClick={() => setShowModal(true)}>
+              <img src={more} alt="더보기" />
+            </button>
+          </>
+        );
+      }
+      case 'top-upload': {
+        return (
+          <>
+            <button onClick={() => navigate(-1)}>
+              <img src={arrowLeft} alt="뒤로가기" />
+            </button>
+            <Button
+              btnTextContent="저장"
+              btnColor={button ? 'normal' : 'disable'}
+              btnSize="mediumSmall"
+              btnType="submit"
+            />
+          </>
+        );
+      }
+      default: {
+        return null;
+      }
+    }
+  };
+
   return (
-    <nav className="flex justify-center w-full h-[48px] border-b border-b-[#DBDBDB] px-[16px] py-[12px]">
-      <div className="flex justify-between items-center w-full max-w-[390px]">
-        <h1 className="text-lg">감귤마켓 피드</h1>
-        <button>
-          <img src={iconSearch} alt="검색" />
-        </button>
-      </div>
-    </nav>
+    <>
+      <nav className="flex justify-center w-full h-[48px] border-b border-b-[#DBDBDB] px-[16px] py-[12px]">
+        <div className="flex justify-between items-center w-full max-w-[390px]">{navContent()}</div>
+      </nav>
+      {(navStyle === 'top-basic' || navStyle === 'top-chat') && showModal && (
+        <Modal closeModal={() => setShowModal(false)} />
+      )}
+    </>
   );
 }
+
 export default Header;

--- a/React/src/components/Header.tsx
+++ b/React/src/components/Header.tsx
@@ -4,20 +4,33 @@ import arrowLeft from '../assets/icon/icon-arrow-left.png';
 import more from '../assets/icon/icon-more-vertical.png';
 import Modal from './modal/Modal';
 import Button from './button/Button';
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 interface IHeaderProps {
   navStyle: 'top-main' | 'top-search' | 'top-basic' | 'top-chat' | 'top-upload';
   button?: boolean;
+  searchValue?: string;
+  searchOnChange?: (e: React.ChangeEvent<HTMLElement>) => void;
 }
 
 /**
- * @param navStyle - 헤더 네비게이션 스타일을 입력하세요. top-main | top-search | top-basic | top-chat | top-upload
- * @param button - (옵셔널) top-upload 스타일 사용시 '저장'버튼의 disabled를 컨트롤 하는 prop입니다.
+ * Header컴포넌트
+ * @param navStyle -string 헤더 네비게이션 스타일을 입력하세요. top-main | top-search | top-basic | top-chat | top-upload
+ * @param button -bloolean (옵셔널) top-upload 스타일 사용시 '저장'버튼의 disabled를 컨트롤 하는 prop입니다.
+ * @param searchValue - (옵셔널) top-search 스타일 사용시 input의 value로 사용되는 문자열
+ * @param searchOnChange - (옵셔널) top-search 스타일 사용시 input의 onChange 핸들러
  * @returns
- * 사용 예시: <Header navStyle="top-upload" button={true} />
+// top-upload 스타일 사용 예시
+ * <Header navStyle="top-upload" button={true} />
+ *
+ * // top-search 스타일 사용 예시. 상위 컴포넌트에서 상태관리를 통해 가져와야 합니다(밑에 예시 setSearchValue)
+ * <Header
+ *   navStyle="top-search"
+ *   searchValue={searchValue}
+ *   searchOnChange={e => setSearchValue(e.target.value)}
+ * />
  */
-function Header({ navStyle, button = false }: IHeaderProps) {
+function Header({ navStyle, button = false, searchValue, searchOnChange }: IHeaderProps) {
   const [showModal, setShowModal] = useState(false);
   const navigate = useNavigate();
 
@@ -43,6 +56,8 @@ function Header({ navStyle, button = false }: IHeaderProps) {
               type="text"
               name="search"
               id="search"
+              value={searchValue}
+              onChange={searchOnChange}
               placeholder="계정 검색"
               className="placeholder:text-[#c4c4c4] bg-[#F2F2F2] w-[316px] h-[32px] rounded-[16px] pl-[16px] py-[7px] text-sm"
             />

--- a/React/src/components/modal/Modal.tsx
+++ b/React/src/components/modal/Modal.tsx
@@ -28,28 +28,32 @@ function Modal({ closeModal }: IModalProps) {
     }, 300);
   };
   return createPortal(
-    <dialog
-      ref={dialogRef}
-      open={isOpen}
-      className={`fixed bottom-0 flex flex-col items-center w-full max-w-[390px] rounded-t-[10px] bg-white shadow-inner
+    <>
+      {/* 백드롭(배경어둡게)용 div */}
+      <div className="fixed inset-0 bg-black bg-opacity-50 z-10" onClick={handleClose} />
+      <dialog
+        ref={dialogRef}
+        open={isOpen}
+        className={`fixed bottom-0 z-20 flex flex-col items-center w-full max-w-[390px] rounded-t-[10px] bg-white shadow-inner
     transition-transform duration-300 ${isOpen ? 'translate-y-0' : 'translate-y-full'}`}
-    >
-      <button type="button" onClick={handleClose}>
-        <img className="w-[50px] h-1 my-4" src={modalBarImg} alt="모달 바" />
-      </button>
-      <ul className="flex flex-col w-[100%] ">
-        {/* li는 기능 작업 시 props를 받아와서 조건부 렌더링으로 switch문으로 처리하기 (switch문 => li를 컴포넌트로 안 만들어도 됨) */}
-        <li className=" ml-[26px] h-[46px] ">
-          <p className="text-[14px] text-left my-[14px] h-[18px]">설정 및 개인정보</p>
-        </li>
-        <li className=" ml-[26px] h-[46px] ">
-          <p className="text-[14px] text-left my-[14px] h-[18px]">로그아웃</p>
-        </li>
-        <li>
-          <div className="h-[10vh]"></div>
-        </li>
-      </ul>
-    </dialog>,
+      >
+        <button type="button" onClick={handleClose}>
+          <img className="w-[50px] h-1 my-4" src={modalBarImg} alt="모달 바" />
+        </button>
+        <ul className="flex flex-col w-[100%] ">
+          {/* li는 기능 작업 시 props를 받아와서 조건부 렌더링으로 switch문으로 처리하기 (switch문 => li를 컴포넌트로 안 만들어도 됨) */}
+          <li className=" ml-[26px] h-[46px] ">
+            <p className="text-[14px] text-left my-[14px] h-[18px]">설정 및 개인정보</p>
+          </li>
+          <li className=" ml-[26px] h-[46px] ">
+            <p className="text-[14px] text-left my-[14px] h-[18px]">로그아웃</p>
+          </li>
+          <li>
+            <div className="h-[10vh]"></div>
+          </li>
+        </ul>
+      </dialog>
+    </>,
     document.body
   );
 }

--- a/React/src/components/modal/Modal.tsx
+++ b/React/src/components/modal/Modal.tsx
@@ -1,16 +1,29 @@
+import { useState } from 'react';
 import modalBarImg from '../../assets/modal-bar.png';
-
-function Modal() {
-  return (
-    <dialog className="fixed bottom-0 flex flex-col items-center w-full min-h-[92px] rounded-t-[10px] bg-white">
-      <img className="w-[50px] h-1 my-4" src={modalBarImg} alt="모달 바" />
+import { createPortal } from 'react-dom';
+interface IModalProps {
+  closeModal: () => void;
+}
+function Modal({ closeModal }: IModalProps) {
+  return createPortal(
+    <dialog className="fixed bottom-0 flex flex-col items-center w-full max-w-[390px] rounded-t-[10px] bg-white shadow-inner">
+      <button type="button" onClick={closeModal}>
+        <img className="w-[50px] h-1 my-4" src={modalBarImg} alt="모달 바" />
+      </button>
       <ul className="flex flex-col w-[100%] ">
         {/* li는 기능 작업 시 props를 받아와서 조건부 렌더링으로 switch문으로 처리하기 (switch문 => li를 컴포넌트로 안 만들어도 됨) */}
         <li className=" ml-[26px] h-[46px] ">
-          <p className="text-[14px] text-left my-[14px] h-[18px]">신고하기</p>
+          <p className="text-[14px] text-left my-[14px] h-[18px]">설정 및 개인정보</p>
+        </li>
+        <li className=" ml-[26px] h-[46px] ">
+          <p className="text-[14px] text-left my-[14px] h-[18px]">로그아웃</p>
+        </li>
+        <li>
+          <div className="h-[10vh]"></div>
         </li>
       </ul>
-    </dialog>
+    </dialog>,
+    document.body
   );
 }
 

--- a/React/src/components/modal/Modal.tsx
+++ b/React/src/components/modal/Modal.tsx
@@ -27,6 +27,7 @@ function Modal({ closeModal }: IModalProps) {
   };
   return createPortal(
     <dialog
+      open={isOpen}
       className={`fixed bottom-0 flex flex-col items-center w-full max-w-[390px] rounded-t-[10px] bg-white shadow-inner
     transition-transform duration-300 ${isOpen ? 'translate-y-0' : 'translate-y-full'}`}
     >

--- a/React/src/components/modal/Modal.tsx
+++ b/React/src/components/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import modalBarImg from '../../assets/modal-bar.png';
 import { createPortal } from 'react-dom';
 interface IModalProps {
@@ -10,11 +10,14 @@ interface IModalProps {
  * @returns
  */
 function Modal({ closeModal }: IModalProps) {
+  const dialogRef = useRef(null);
+
   //모달 열렸는지 상태
   const [isOpen, setIsOpen] = useState(false);
   //settimeout을 안하면 바로 올라와서 지연시킴. 렌더링시 Open=true
   useEffect(() => {
     setTimeout(() => {
+      dialogRef.current.showModal();
       setIsOpen(true);
     }, 10);
   }, []);
@@ -27,6 +30,7 @@ function Modal({ closeModal }: IModalProps) {
   };
   return createPortal(
     <dialog
+      ref={dialogRef}
       open={isOpen}
       className={`fixed bottom-0 flex flex-col items-center w-full max-w-[390px] rounded-t-[10px] bg-white shadow-inner
     transition-transform duration-300 ${isOpen ? 'translate-y-0' : 'translate-y-full'}`}

--- a/React/src/components/modal/Modal.tsx
+++ b/React/src/components/modal/Modal.tsx
@@ -1,13 +1,36 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import modalBarImg from '../../assets/modal-bar.png';
 import { createPortal } from 'react-dom';
 interface IModalProps {
   closeModal: () => void;
 }
+/**
+ * 모달 컴포넌트
+ * @param closeModal - setShowModal(false)를 콜백으로 받음
+ * @returns
+ */
 function Modal({ closeModal }: IModalProps) {
+  //모달 열렸는지 상태
+  const [isOpen, setIsOpen] = useState(false);
+  //settimeout을 안하면 바로 올라와서 지연시킴. 렌더링시 Open=true
+  useEffect(() => {
+    setTimeout(() => {
+      setIsOpen(true);
+    }, 10);
+  }, []);
+  //버튼 온클릭 이벤트 핸들러  setOpen(false)로 애니메이션(밑에 duration-300)이 지나고 닫히도록 딜레이함.
+  const handleClose = () => {
+    setIsOpen(false);
+    setTimeout(() => {
+      closeModal();
+    }, 300);
+  };
   return createPortal(
-    <dialog className="fixed bottom-0 flex flex-col items-center w-full max-w-[390px] rounded-t-[10px] bg-white shadow-inner">
-      <button type="button" onClick={closeModal}>
+    <dialog
+      className={`fixed bottom-0 flex flex-col items-center w-full max-w-[390px] rounded-t-[10px] bg-white shadow-inner
+    transition-transform duration-300 ${isOpen ? 'translate-y-0' : 'translate-y-full'}`}
+    >
+      <button type="button" onClick={handleClose}>
         <img className="w-[50px] h-1 my-4" src={modalBarImg} alt="모달 바" />
       </button>
       <ul className="flex flex-col w-[100%] ">

--- a/React/src/components/modal/Modal.tsx
+++ b/React/src/components/modal/Modal.tsx
@@ -17,7 +17,6 @@ function Modal({ closeModal }: IModalProps) {
   //settimeout을 안하면 바로 올라와서 지연시킴. 렌더링시 Open=true
   useEffect(() => {
     setTimeout(() => {
-      dialogRef.current.showModal();
       setIsOpen(true);
     }, 10);
   }, []);


### PR DESCRIPTION
## 제목

Feat/헤더,모달컴포넌트(임시) 기능구현

## 변경사항 요약

헤더 종류별로 렌더링 구현
각 종류에 맞는 이벤트 구현(뒤로가기, 더보기(모달), 인풋 이벤트처리)

- 주요 변경점

Header컴포넌트 작성
switch case문으로 각 스타일 구현

Modal 렌더링기능 구현(미완성)
헤더에서 더보기 클릭시 모달이 나타나고 사라지는 기능 간단하게 구현


## 스크린샷

(top-main) -> (top-basic) -> 모달 -> 뒤로가기

![화면 기록 2025-09-13 17 34 51](https://github.com/user-attachments/assets/72fe8e50-1cf5-4226-b31a-85242f3b77e3)

(top-search) -> 인풋창 인터렉션은 상위에서 상태관리로 받아야함
![화면 기록 2025-09-13 17 38 12](https://github.com/user-attachments/assets/c4a9bdfb-5ac1-41b2-a98b-66a81b539673)

(top-chat) -> 채팅 기능이 추후 구현 기능이라 하드코딩 되어있음
<img width="490" height="122" alt="스크린샷 2025-09-13 17 42 25" src="https://github.com/user-attachments/assets/ffc7df8a-107a-4fa8-8d6d-574cff4a208f" />

(top-upload) 버튼의 색상으로 disabled가 컨트롤됨 (자세한컨 Button컴포넌트 참고) // 타입이 submit임으로 상위에서 form으로 이벤트 처리해주세요.
<img width="496" height="135" alt="스크린샷 2025-09-13 17 48 01" src="https://github.com/user-attachments/assets/d52d81ef-ce8b-4d65-8bf5-cd929004e719" />

## 리뷰어
@MeinSchatzMeinSatz @gyeone 