### PR TITLE
Feature/search page

### DIFF
--- a/React/src/App.jsx
+++ b/React/src/App.jsx
@@ -6,7 +6,6 @@ import HomePage from './pages/home/HomePage';
 import Login from './pages/Auth/Login';
 import LoginWithEmail from './pages/Auth/LoginWithEmail';
 import JoinMembership from './pages/Auth/JoinMembership';
-import MembershipProfile from './pages/Auth/MembershipProfile';
 import SearchPage from './pages/search/SearchPage';
 import YourProfile from './pages/yourprofile/YourProfile';
 import MyProfile from './pages/myprofile/MyProfile';
@@ -26,7 +25,6 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/login-with-email" element={<LoginWithEmail />} />
         <Route path="/join-membership" element={<JoinMembership />} />
-        <Route path="/membership-profile" element={<MembershipProfile />} />
         <Route path="/search-page" element={<SearchPage />} />
         <Route path="/your-profile" element={<YourProfile />} />
         <Route path="/my-profile" element={<MyProfile />} />

--- a/React/src/components/Header.tsx
+++ b/React/src/components/Header.tsx
@@ -3,13 +3,12 @@ import iconSearch from '../assets/icon/icon-search.png';
 import arrowLeft from '../assets/icon/icon-arrow-left.png';
 import more from '../assets/icon/icon-more-vertical.png';
 import Modal from './modal/Modal';
-import Button from './Button/Button';
+import Button from './button/Button';
 import React, { useState } from 'react';
 
 interface IHeaderProps {
   navStyle: 'top-main' | 'top-search' | 'top-basic' | 'top-chat' | 'top-upload' | 'top-save';
   button?: boolean;
-  searchValue?: string;
   searchOnChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -30,7 +29,7 @@ interface IHeaderProps {
  *   searchOnChange={e => setSearchValue(e.target.value)}
  * />
  */
-function Header({ navStyle, button = false, searchValue, searchOnChange }: IHeaderProps) {
+function Header({ navStyle, button = false, searchOnChange }: IHeaderProps) {
   const [showModal, setShowModal] = useState(false);
   const navigate = useNavigate();
 
@@ -56,7 +55,8 @@ function Header({ navStyle, button = false, searchValue, searchOnChange }: IHead
               type="text"
               name="search"
               id="search"
-              value={searchValue}
+              value="애월읍"
+              readOnly
               onChange={searchOnChange}
               placeholder="계정 검색"
               className="placeholder:text-[#c4c4c4] bg-[#F2F2F2] w-[316px] h-[32px] rounded-[16px] pl-[16px] py-[7px] text-sm"

--- a/React/src/pages/Auth/components/LoginSignUpForm.tsx
+++ b/React/src/pages/Auth/components/LoginSignUpForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useState } from 'react';
-import Button from '../../../components/Button/Button';
+import Button from '../../../components/button/Button';
 import TextInput from '../../../components/TextInput';
 import postLogin from '../../../service/user/postLogin';
 

--- a/React/src/pages/home/HomePage.tsx
+++ b/React/src/pages/home/HomePage.tsx
@@ -5,7 +5,7 @@ import Footer from '../../components/footer/Footer';
 function HomePage() {
   return (
     <div>
-      <Header />
+      <Header navStyle="top-main" />
       <div className="mt-[220px] flex flex-col items-center gap-[20px]">
         <img src={Symbol} alt="로고" />
         <p className="text-[#767676]">유저를 검색해 팔로우 해보세요!</p>

--- a/React/src/pages/search/SearchPage.tsx
+++ b/React/src/pages/search/SearchPage.tsx
@@ -5,7 +5,7 @@ import UserProfile from '../../components/UserProfile';
 function SearchPage() {
   return (
     <>
-      <Header />
+      <Header navStyle="top-search" />
       <ul className="flex flex-col gap-4 mt-5 mx-4">
         <UserProfile username="애월읍 위니브 감귤농장" accountname="@ weniv_Mandarin" />
         <UserProfile username="애월읍 한라봉 최고 맛집" accountname="@ hanlabong" />


### PR DESCRIPTION
## 제목

- feat/searchPage 검색 기능 구현 

## 변경사항 요약

- feat/searchPage에서 header컴포넌트로 props전달 (헤더 검색 창 보이게 함)
- feat/homePage에서 header컴포넌트로 props전달 (홈 페이지에서 검색 페이지로 이동 가능)
- feat/searchPage헤더 input의 value값 readOnly로 지정 (검색 기능은 마크업만 구현하므로 검색어 고정)

## 검색 페이지 기능
- [x]  검색 기능 없이 마크업만 구현
- [x]  홈 화면에서 검색 버튼 클릭 시 검색하는 페이지로 이동

## 스크린샷

<img width="381" height="826" alt="image" src="https://github.com/user-attachments/assets/b8e3b4da-7a10-4add-be04-0456749dd2ed" />

## 리뷰어

- @MeinSchatzMeinSatz @MinKyeongHyeon 
