### PR TITLE
Refactor/chat list 중앙 정렬, 링크 이동 수단 변경

### DIFF
--- a/React/src/pages/chat/ChatList.tsx
+++ b/React/src/pages/chat/ChatList.tsx
@@ -35,6 +35,7 @@ function ChatList() {
             </div>
             <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
           </Link>
+      <ul className="flex flex-col  w-[390px] mx-auto gap-5 pt-6 px-[16px]">
         </li>
         <li className="flex gap-3 items-end w-full justify-between">
           <Link to="/chat-room">

--- a/React/src/pages/chat/ChatList.tsx
+++ b/React/src/pages/chat/ChatList.tsx
@@ -1,53 +1,48 @@
 import Footer from '../../components/footer/Footer';
 import Header from '../../components/Header';
 import profileImg from '../../assets/basic-profile-img.png';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 function ChatList() {
+  const navigate = useNavigate();
+
   return (
     <>
       <Header navStyle="top-basic" />
-      <ul className="flex flex-col gap-5 pt-6 px-[16px]">
-        <li className="flex gap-3 items-end w-full justify-between">
-          <Link to="/chat-room">
-            <div className="relative">
-              <span className="w-3 h-3 bg-[#F26E22] rounded-full absolute top-0"></span>
-              <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
-            </div>
-            <div className="flex flex-col gap-1 flex-1 ">
-              <h2 className="text-sm font-medium">애월읍 위니브 감귤농장</h2>
-              <p className="text-[12px] text-[#767676] mb-[3px]">이번에 정정 언제하맨마씸?</p>
-            </div>
-            <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
-          </Link>
-        </li>
-        <li className="flex gap-3 items-end w-full justify-between">
-          <Link to="/chat-room">
-            <div className="relative">
-              <span className="w-3 h-3 bg-[#F26E22] rounded-full absolute top-0"></span>
-              <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
-            </div>
-            <div className="flex flex-col gap-1 flex-1 min-w-0">
-              <h2 className="text-sm font-medium">제주감귤마을</h2>
-              <p className="text-[12px] text-[#767676] mb-[3px] truncate">
-                깊은 어둠의 존재감, 롤스로이스 뉴 블랙 배지...
-              </p>
-            </div>
-            <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
-          </Link>
       <ul className="flex flex-col  w-[390px] mx-auto gap-5 pt-6 px-[16px]">
-        </li>
-        <li className="flex gap-3 items-end w-full justify-between">
-          <Link to="/chat-room">
+        <li className="flex gap-3 items-end w-full justify-between" onClick={() => navigate('/chat-room')}>
+          <div className="relative">
+            <span className="w-3 h-3 bg-[#F26E22] rounded-full absolute top-0"></span>
             <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
-            <div className="flex flex-col gap-1 flex-1 min-w-0">
-              <h2 className="text-sm font-medium">누구네 농장 친환경 한라봉</h2>
-              <p className="text-[12px] text-[#767676] mb-[3px] truncate">
-                내 차는 내가 평가한다. 오픈 이벤트에 참여 하...
-              </p>
-            </div>
-            <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
-          </Link>
+          </div>
+          <div className="flex flex-col gap-1 flex-1 ">
+            <h2 className="text-sm font-medium">애월읍 위니브 감귤농장</h2>
+            <p className="text-[12px] text-[#767676] mb-[3px]">이번에 정정 언제하맨마씸?</p>
+          </div>
+          <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
+        </li>
+        <li className="flex gap-3 items-end w-full justify-between" onClick={() => navigate('/chat-room')}>
+          <div className="relative">
+            <span className="w-3 h-3 bg-[#F26E22] rounded-full absolute top-0"></span>
+            <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
+          </div>
+          <div className="flex flex-col gap-1 flex-1 min-w-0">
+            <h2 className="text-sm font-medium">제주감귤마을</h2>
+            <p className="text-[12px] text-[#767676] mb-[3px] truncate">
+              깊은 어둠의 존재감, 롤스로이스 뉴 블랙 배지...
+            </p>
+          </div>
+          <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
+        </li>
+        <li className="flex gap-3 items-end w-full justify-between" onClick={() => navigate('/chat-room')}>
+          <img src={profileImg} alt="채팅 상대방 프로필 이미지" className="w-[42px] h-[42px] rounded-full" />
+          <div className="flex flex-col gap-1 flex-1 min-w-0">
+            <h2 className="text-sm font-medium">누구네 농장 친환경 한라봉</h2>
+            <p className="text-[12px] text-[#767676] mb-[3px] truncate">
+              내 차는 내가 평가한다. 오픈 이벤트에 참여 하...
+            </p>
+          </div>
+          <time className="text-[10px] text-[#DBDBDB] ml-[1px]">2020.10.25</time>
         </li>
       </ul>
       <Footer />


### PR DESCRIPTION
## 제목

- Refactor/chat list 중앙 정렬, 링크 이동 수단 변경

## 변경사항 요약

- refactor/채팅 목록 중앙으로 정렬
- refactor/link태그로 인한 스타일 적용 안됨을 useNavigate로 해결(ul 태그 직속 자식이 li 태그여야 시맨틱함, 그러므로 link 태그가 li직속 자식으로 설정 했더니 li 태그의 flex 관련 속성들이 적용 안됨 => useNavigate로 변경)    

    변경 전 ⬇ 
    <img width="479" height="68" alt="image" src="https://github.com/user-attachments/assets/da901569-b593-4588-a2ae-0da50100122f" />  

    변경 후 ⬇    
    <img width="682" height="40" alt="image" src="https://github.com/user-attachments/assets/6269959d-5744-436f-bdac-30e7a3d702b9" />



## 스크린샷

<img width="587" height="850" alt="image" src="https://github.com/user-attachments/assets/2d70bc11-f282-4134-9203-c3fdba0f4f3a" />

## 리뷰어

- @MeinSchatzMeinSatz @MinKyeongHyeon 
