### PR TITLE
Feature/posting component for post page

### DIFF
--- a/React/src/App.jsx
+++ b/React/src/App.jsx
@@ -31,7 +31,7 @@ function App() {
         <Route path="/followers-list" element={<FollowersList />} />
         <Route path="/profile-modification" element={<ProfileModification />} />
         <Route path="/add-product" element={<AddProduct />} />
-        <Route path="/post" element={<Post />} />
+        <Route path="/post/:id" element={<Post />} />
         <Route path="/upload" element={<Upload />} />
         <Route path="/chat-list" element={<ChatList />} />
         <Route path="/chat-room" element={<ChatRoom />} />

--- a/React/src/Utils/validation.ts
+++ b/React/src/Utils/validation.ts
@@ -44,6 +44,20 @@ function validatePassword(password: string) {
   return isOk;
 }
 
+//=============상세 게시글 url용 validate 함수 ==============
+
+/**
+ * 상세 게시글(post)페이지 url 함수
+ * @param url - 현재 페이지 url 작성 (window.location.href)
+ * @returns {boolean}
+ **/
+
+function validateUrl(url: string) {
+  const urlRegex = /^.+\/post\/:.+$/;
+  let isOk = urlRegex.test(url);
+  return isOk;
+}
+
 //=============상품 등록용 validate 함수 ==============
 /**
  * 상품명 검증 함수
@@ -71,7 +85,6 @@ function validateProductPrice(productPrice: string) {
  *  @returns {boolean}
  */
 function validateProductURL(productURL: string) {
-
   const productPriceRegex = /^(https?|ftp):\/\/(-\.)?([^\s\/?\.#-]+\.?)+(\/[^\s]*)?$/i;
   let isOk = productPriceRegex.test(productURL);
   return isOk;
@@ -81,6 +94,7 @@ export {
   validateEmail,
   validateUserName,
   validatePassword,
+  validateUrl,
   validateId,
   validateProductName,
   validateProductPrice,

--- a/React/src/components/Posting.tsx
+++ b/React/src/components/Posting.tsx
@@ -4,6 +4,7 @@ import iconHeart from '../assets/icon/icon-heart.png';
 import iconMessage from '../assets/icon/icon-message-circle.svg';
 import iconImgLayers from '../assets/icon/iccon-img-layers.png';
 import { imageAPI } from '../service/fetch/api';
+import { useNavigate } from 'react-router-dom';
 
 // 리스트형 / 앨범형 선택을 위한 props 타입
 /**
@@ -45,6 +46,9 @@ function Posting({
   const profileImg = basicProfileImg;
   // 아마자 랜더링을 위한 기본 url
   const imgUrl = 'https://dev.wenivops.co.kr/services/mandarin/';
+
+  // 라우팅
+  const navigate = useNavigate();
 
   // 이미지 배열 전환 함수
   function makeArray() {
@@ -105,7 +109,7 @@ function Posting({
                 </button>
                 <span className="text-[12px] text-[#767676]">{heartCount}</span>
               </div>
-              <div className="flex gap-[6px] items-center">
+              <div className="flex gap-[6px] items-center" onClick={() => navigate('/post')}>
                 <button className="w-5 h-5">
                   <img src={iconMessage} alt="댓글" />
                 </button>

--- a/React/src/components/Posting.tsx
+++ b/React/src/components/Posting.tsx
@@ -114,7 +114,8 @@ function Posting({
                 </button>
                 <span className="text-[12px] text-[#767676]">{heartCount}</span>
               </div>
-              <div className="flex gap-[6px] items-center" onClick={() => navigate('/post')}>
+              {/* 댓글 버튼이나 댓글수 눌렀을 때 상세 페이지로 이동 */}
+              <div className="flex gap-[6px] items-center" onClick={() => navigate(`/post/${id}`, { state: { post } })}>
                 <button className="w-5 h-5">
                   <img src={iconMessage} alt="댓글" />
                 </button>

--- a/React/src/components/Posting.tsx
+++ b/React/src/components/Posting.tsx
@@ -48,9 +48,8 @@ function Posting({
   commentCount,
   updatedAt,
 }: PostingProps) {
+  // 기본 프로필 유저 이미지
   const profileImg = basicProfileImg;
-  // 이미지 랜더링을 위한 기본 url
-  const imgUrl = 'https://dev.wenivops.co.kr/services/mandarin/';
 
   // 라우팅
   const navigate = useNavigate();
@@ -77,6 +76,7 @@ function Posting({
 
   // 이미지 배열을 변수에 할당
   const contentImageArray = makeArray();
+  console.log(contentImageArray);
 
   // 날짜 형식 변환 함수
   function formatDate(dateString: string) {
@@ -112,7 +112,7 @@ function Posting({
               ? contentImageArray.map((image: string, index: number) => (
                   <img
                     className="w-[304px] h-[228px] rounded-[10px] border-[0.5px] border-[#DBDBDB] object-cover bg-[#C4C4C4] ]"
-                    src={imgUrl + image}
+                    src={imageAPI.getImage(image)}
                     key={index}
                     alt="게시글이미지"
                   />
@@ -150,7 +150,7 @@ function Posting({
           {contentImage && (
             <li className={`relative w-full aspect-square ${contentImage ? '' : 'hidden'}`}>
               <img
-                src={contentImageArray && imgUrl + contentImageArray[0]}
+                src={contentImageArray && imageAPI.getImage(contentImageArray[0])}
                 alt="게시글 이미지"
                 className="w-full h-full object-cover"
               />

--- a/React/src/components/Posting.tsx
+++ b/React/src/components/Posting.tsx
@@ -126,8 +126,14 @@ function Posting({
                 <span className="text-[12px] text-[#767676]">{heartCount}</span>
               </div>
               {/* 댓글 버튼이나 댓글수 눌렀을 때 상세 페이지로 이동 */}
-              <div className="flex gap-[6px] items-center" onClick={() => navigate(`/post/${id}`, { state: { post } })}>
-                <button className="w-5 h-5">
+              <div
+                className={`flex gap-[6px] items-center ${!urlRegex.test(window.location.href) && 'cursor-pointer'} `}
+                onClick={commentNavigate}
+              >
+                <button
+                  className={`w-5 h-5 ${urlRegex.test(window.location.href) ? 'cursor-default' : 'cursor-pointer'}`}
+                  type="button"
+                >
                   <img src={iconMessage} alt="댓글" />
                 </button>
                 <span className="text-[12px] text-[#767676]">{commentCount}</span>

--- a/React/src/components/Posting.tsx
+++ b/React/src/components/Posting.tsx
@@ -5,6 +5,7 @@ import iconMessage from '../assets/icon/icon-message-circle.svg';
 import iconImgLayers from '../assets/icon/iccon-img-layers.png';
 import { imageAPI } from '../service/fetch/api';
 import { useNavigate } from 'react-router-dom';
+import { PostAPI } from '../types/IFetchType';
 
 // 리스트형 / 앨범형 선택을 위한 props 타입
 /**
@@ -22,6 +23,8 @@ import { useNavigate } from 'react-router-dom';
  */
 type PostingProps = {
   showList?: boolean;
+  id?: string;
+  post?: PostAPI.IPost;
   userProfileImage: string;
   userName: string;
   userId: string;
@@ -34,6 +37,8 @@ type PostingProps = {
 
 function Posting({
   showList = true,
+  id,
+  post,
   userProfileImage,
   userName,
   userId,

--- a/React/src/components/Posting.tsx
+++ b/React/src/components/Posting.tsx
@@ -49,7 +49,7 @@ function Posting({
   updatedAt,
 }: PostingProps) {
   const profileImg = basicProfileImg;
-  // 아마자 랜더링을 위한 기본 url
+  // 이미지 랜더링을 위한 기본 url
   const imgUrl = 'https://dev.wenivops.co.kr/services/mandarin/';
 
   // 라우팅

--- a/React/src/components/Posting.tsx
+++ b/React/src/components/Posting.tsx
@@ -55,6 +55,9 @@ function Posting({
   // 라우팅
   const navigate = useNavigate();
 
+  // 상세 게시글(post)페이지인 url 정규 표현식
+  const urlRegex = /^.+\/post\/:.+$/;
+
   // 이미지 배열 전환 함수
   function makeArray() {
     if (contentImage === undefined) {
@@ -62,6 +65,14 @@ function Posting({
     }
 
     return contentImage.split(',');
+  }
+
+  function commentNavigate() {
+    // 현재 페이지가 상세 게시글(post)페이지일 경우 링크 이동x
+    if (urlRegex.test(window.location.href)) {
+      return;
+    }
+    navigate(`/post/:${id}`, { state: { post } });
   }
 
   // 이미지 배열을 변수에 할당

--- a/React/src/components/Posting.tsx
+++ b/React/src/components/Posting.tsx
@@ -6,6 +6,7 @@ import iconImgLayers from '../assets/icon/iccon-img-layers.png';
 import { imageAPI } from '../service/fetch/api';
 import { useNavigate } from 'react-router-dom';
 import { PostAPI } from '../types/IFetchType';
+import { validateUrl } from '../Utils/validation';
 
 // 리스트형 / 앨범형 선택을 위한 props 타입
 /**
@@ -54,9 +55,6 @@ function Posting({
   // 라우팅
   const navigate = useNavigate();
 
-  // 상세 게시글(post)페이지인 url 정규 표현식
-  const urlRegex = /^.+\/post\/:.+$/;
-
   // 이미지 배열 전환 함수
   function makeArray() {
     if (contentImage === undefined) {
@@ -68,7 +66,7 @@ function Posting({
 
   function commentNavigate() {
     // 현재 페이지가 상세 게시글(post)페이지일 경우 링크 이동x
-    if (urlRegex.test(window.location.href)) {
+    if (validateUrl(window.location.href)) {
       return;
     }
     navigate(`/post/:${id}`, { state: { post } });
@@ -127,11 +125,11 @@ function Posting({
               </div>
               {/* 댓글 버튼이나 댓글수 눌렀을 때 상세 페이지로 이동 */}
               <div
-                className={`flex gap-[6px] items-center ${!urlRegex.test(window.location.href) && 'cursor-pointer'} `}
+                className={`flex gap-[6px] items-center ${!validateUrl(window.location.href) && 'cursor-pointer'} `}
                 onClick={commentNavigate}
               >
                 <button
-                  className={`w-5 h-5 ${urlRegex.test(window.location.href) ? 'cursor-default' : 'cursor-pointer'}`}
+                  className={`w-5 h-5 ${validateUrl(window.location.href) ? 'cursor-default' : 'cursor-pointer'}`}
                   type="button"
                 >
                   <img src={iconMessage} alt="댓글" />

--- a/React/src/pages/Auth/components/LoginSignUpForm.tsx
+++ b/React/src/pages/Auth/components/LoginSignUpForm.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import Button from '../../../components/button/Button';
 import TextInput from '../../../components/TextInput';
 import { userAPI } from '../../../service/fetch/api';
-import { validateEmail, validateId, validatePassword, validateUserName } from '../../../Utils/validation';
+import { validateEmail, validateId, validatePassword } from '../../../Utils/validation';
 import { useNavigate } from 'react-router-dom';
 import ImgBtn from '../../../assets/upload-file.png';
 

--- a/React/src/pages/home/HomePage.tsx
+++ b/React/src/pages/home/HomePage.tsx
@@ -48,7 +48,12 @@ function HomePage() {
               <ul className="flex flex-col items-center gap-5 pt-5 px-4">
                 {posts.map((post) => (
                   <Posting
+                    // 포스팅 컴포넌트에 대한 key
                     key={post.id}
+                    // 각 게시글의 고유 id
+                    id={post.id}
+                    // 각 게시글 모든 내용(navigate의 state 값으로 넘기기 위한 props)
+                    post={post}
                     userProfileImage={post.author.image}
                     userName={post.author.username}
                     userId={post.author.accountname}

--- a/React/src/types/IFetchType.ts
+++ b/React/src/types/IFetchType.ts
@@ -210,7 +210,7 @@ export namespace PostAPI {
 
   // 게시글 상세 조회
   export interface IPostDetailResponse {
-    post: IPost[];
+    post: IPost;
   }
 
   // 게시글 수정


### PR DESCRIPTION
## 제목

- post페이지에 해당 게시글을 넘겨주기 위한 posting컴포넌트에 기능 추가

## 변경사항 요약

- feat/homePage에서 posting컴포넌트로 넘겨주는 props추가(id, post)
- feat/현재 페이지가 상세 게시글(post)페이지일 경우 링크 이동 금지 기능 구현
-  feat/페이지 이동 시 url에 파라미터 추가와 state(useNavigate 속성)넘겨주기
- feat/현재 페이지가 상세 게시글(post)페이지일 경우 커서 포인터를 기본 상태로 처리, 아닐 겨우 커서 포인터 처리(댓글 수도 커서 포인터와 링크 이동 기능 처리 같이 함)
- refactor/특정 게시글은 배열이 아니기 때문에 게시글 상세 조회 응답 값 배열 타입 삭제
- feat/post페이지 url에 파라미터 추가했기 때문에 App.jsx의 route post 경로 수정

## 전달할 현재 상황과 추후 고려 사항

1. 현재 home페이지에서만 (유저가 클릭한) 해당 게시글 내용을 post페이지로 보내주고 있음(props를 전달하고 있음)     
     - homePage의 posting컴포넌트 props ⬇  (새로 추가한 props: id, post)
      <img width="640" height="175" alt="image" src="https://github.com/user-attachments/assets/72a4d0a0-d663-4d26-b155-c66b90378c64" />
2.  posting 컴포넌트를 사용하는 여러 페이지에서 에러가 나지 않게 하기 위해 임시로 타입을 옵셔널로 해둠 
      => 추후에 필수 타입으로 변경해야 함 ⬇
      <img width="249" height="59" alt="image" src="https://github.com/user-attachments/assets/2d0c4505-deb2-4c53-a65b-5bc7d661f65f" />


## 스크린샷
 - url 참고 스크린샷 (pr엔 올리진 않았지만 일단 게시글 불러오기 성공! 댓글 기능은 아직 안 함)
<img width="652" height="981" alt="image" src="https://github.com/user-attachments/assets/85388626-8cb1-4e7f-a0cb-7999e7d2dffa" />

## 리뷰어

- @MeinSchatzMeinSatz @MinKyeongHyeon 
