### PR TITLE
bug/login 로그인시 오류 메시지 랜더링 부분 수정

### DIFF
--- a/React/src/pages/Auth/components/LoginSignUpForm.tsx
+++ b/React/src/pages/Auth/components/LoginSignUpForm.tsx
@@ -92,10 +92,8 @@ export default function LoginSignUpForm({ formName, btnText, isLogin }: LoginSig
       setPwError(true);
 
       // 실패 처리
-      if (error.status === 422) {
-        setPwErrorMessage(error.message);
-        return;
-      }
+      setPwErrorMessage(error.message);
+      return;
     } finally {
       setLoading(false);
       setPassword('');


### PR DESCRIPTION
## 제목

- bug/login 로그인시 오류 메시지 랜더링 부분 수정

## 변경사항 요약

- 로그인시 비밀번호 불일치시 오류 메시지가 랜더링에 오류가 있었는데, 해당 부분을 수정했습니다.

## 스크린샷

<img width="428" height="447" alt="스크린샷 2025-09-23 오후 4 01 41" src="https://github.com/user-attachments/assets/a9a6f64d-4453-4972-8a52-6ea258453e58" />

# 이슈번호
bug/로그인 비밀번호 에러 메세지 출력안됨 #68 


## 리뷰어

- @MinKyeongHyeon @gyeone 
