### PR TITLE
feat/회원 가입 시 유저 프로필 기본 이미지 설정해주기

### DIFF
--- a/React/src/pages/Auth/components/LoginSignUpForm.tsx
+++ b/React/src/pages/Auth/components/LoginSignUpForm.tsx
@@ -6,6 +6,7 @@ import { userAPI } from '../../../service/fetch/api';
 import { validateEmail, validateId, validatePassword } from '../../../Utils/validation';
 import { useNavigate } from 'react-router-dom';
 import ImgBtn from '../../../assets/upload-file.png';
+import profileImg from '../../../assets/Ellipse-1.png';
 
 /**
  * @param formName - form에 들어갈 텍스트를 기입해주세요.
@@ -323,7 +324,11 @@ export default function LoginSignUpForm({ formName, btnText, isLogin }: LoginSig
           </header>
           <main>
             <div className="my-[30px] flex flex-col items-center relative">
-              <img className="w-[110px] h-[110px] rounded-full " src={userImg} alt="내 프로필 이미지" />
+              <img
+                className="w-[110px] h-[110px] rounded-full "
+                src={!userImg || userImg === '/Ellipse.png' ? profileImg : userImg}
+                alt="내 프로필 이미지"
+              />
               <label
                 className=" w-9 h-9 rounded-full absolute bottom-0 translate-x-[37px]  cursor-pointer"
                 htmlFor="userImgSelectBtn"


### PR DESCRIPTION
## 제목

- feat/회원 가입 시 유저 프로필 기본 이미지 설정해주기

## 변경사항 요약

- 유저 프로필 이미지의 기본 이미지가 없었던 부분 해결

## 스크린샷

<img width="516" height="705" alt="image" src="https://github.com/user-attachments/assets/df93076e-4b76-4e2a-b69f-67be89a4ec8d" />

## 리뷰어

- @MeinSchatzMeinSatz @MinKyeongHyeon 
