### PR TITLE
feat/공통 버튼 컴포넌트에 throttle 함수 적용

### DIFF
--- a/React/src/components/Button/Button.tsx
+++ b/React/src/components/Button/Button.tsx
@@ -1,4 +1,5 @@
 import { IBtnType, ButtonSizeType, ButtonColorType } from '../../types/IButtonType';
+import throttle from '../../Utils/throttle';
 
 // 버튼 사이즈별 상수 정의
 const BUTTON_SIZES = {
@@ -23,7 +24,7 @@ function getButtonColor(color: ButtonColorType) {
   return BUTTON_COLORS[color] || BUTTON_COLORS.normal;
 }
 
-export default function Button({
+function Button({
   btnTextContent,
   btnSize,
   btnColor,
@@ -33,11 +34,14 @@ export default function Button({
 
   btnForm,
 }: IBtnType) {
+  const handleThrottle = onClick ? throttle(onClick, 3000) : undefined;
+  console.log(handleThrottle);
+
   return (
     <button
       type={btnType}
       className={`flex justify-center items-center py-[14px] px-[11px] font-medium ${getButtonSize(btnSize)} ${getButtonColor(btnColor)} ${btnFlexBasis}`}
-      onClick={onClick}
+      onClick={handleThrottle}
       disabled={btnColor === 'disable' ? true : false}
       form={btnForm}
     >
@@ -45,3 +49,5 @@ export default function Button({
     </button>
   );
 }
+
+export default Button;

--- a/React/src/components/Button/FollowToggleButton.tsx
+++ b/React/src/components/Button/FollowToggleButton.tsx
@@ -41,8 +41,8 @@ function FollowToggleButton({ followText, unfollowText, btnSize, userAccount, is
         const res = await profileAPI.follow(userAccount);
         setIsFollowing(res.profile.isfollow);
       }
-    } catch (error) {
-      console.log(error);
+    } catch (error: any) {
+      console.error('팔로우 또는 언팔로우를 실패하였습니다.', error.message);
     }
   }
 

--- a/React/src/components/Button/FollowToggleButton.tsx
+++ b/React/src/components/Button/FollowToggleButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useState, useEffect } from 'react';
 import { IFollowToggleButtonType, ButtonSizeType, ButtonColorType } from '../../types/IFollowToggleButtonType';
 import { profileAPI } from '../../service/fetch/api';
+import throttle from '../../Utils/throttle';
 
 // 버튼 사이즈별 상수 정의
 const BUTTON_SIZES = {
@@ -45,12 +46,14 @@ function FollowToggleButton({ followText, unfollowText, btnSize, userAccount, is
     }
   }
 
+  const handleThrottle = throttle(handleFollowToggle, 1000);
+
   return (
     <>
       <button
         type="button"
         className={`flex justify-center items-center py-[14px] px-[11px] font-medium ${getButtonSize(btnSize)} ${getButtonColor(isFollowing ? 'active' : 'normal')}`}
-        onClick={handleFollowToggle}
+        onClick={handleThrottle}
       >
         {isFollowing ? unfollowText : followText}
       </button>


### PR DESCRIPTION
## 제목

- feat/ throttle 함수 적용하기
- 
## 변경사항 요약

- 공통 컴포넌트인 기본 버튼 onClick시 throttle 기능 적용 완료
- 공통 컴포넌트인 팔로우 언팔로우 버튼 onClick시 throttle 기능 적용 완료

## 스크린샷

### 1. 업로드 페이지에서 업로드 버튼 클릭 후 중복되는 게시물 있는지 확인해본 실험 결과
#### 게시물 내용으로 중복됐는지 확인 가능함

<img width="432" height="848" alt="image" src="https://github.com/user-attachments/assets/bb5c7d1f-0b54-46a2-bebd-84300b9885c5" />

### 2. 상대방 프로필에서 팔로우와 언팔로우 토글 버튼 클릭 시 적용 잘 되는지 확인 완료

#### 적용 전: api호출이 반복되어 에러 남

<img width="655" height="352" alt="image" src="https://github.com/user-attachments/assets/efd15554-96f4-408a-bf54-7b7b09a893d3" />

#### 적용 후: 최소 1초 이후에 api호출 가능하게 하여 아무리 빨리 눌러도 에러 안 남 

<img width="655" height="267" alt="image" src="https://github.com/user-attachments/assets/20e39513-770e-4053-b8e1-285949845efc" />




## 리뷰어

- @MeinSchatzMeinSatz @MinKyeongHyeon 
